### PR TITLE
format code output (display, stdin, and stderr) in html and in pdf

### DIFF
--- a/_extensions/computo/_extension.yml
+++ b/_extensions/computo/_extension.yml
@@ -6,18 +6,19 @@ contributes:
     common:
       # define below YAML configuration common to all formats
       filters:
-        # You can include here Lua filters from your extension format 
+        # You can include here Lua filters from your extension format
         - color-text.lua
         - list-table.lua
         - pseudocode.lua
         - not-in-format.lua
+        - code-block-all.lua
       shortcodes:
         # You can include here Lua filters defining shortcodes from your extension
         - shortcodes.lua
       knitr:
         opts_chunk:
           echo: true
-          screenshot.opts: 
+          screenshot.opts:
             cliprect: viewport
             vwidth: 640
             vheight: 400
@@ -27,7 +28,7 @@ contributes:
       code-copy: true
       code-block-background: true
     html:
-      theme: custom.scss
+      theme: [code-block-all.scss, custom.scss]
       title-block-banner: "#034E79"
       title-block-banner-color: "#FFFFFF"
       license: "CC BY"
@@ -43,14 +44,14 @@ contributes:
         caption: "source"
       code-copy: true
       code-summary: "Hide/Show the code"
-      code-fold: show
+      code-fold: false
       anchor-sections: true
       link-external-icon: false
       link-external-newwindow: true
       crossref:
       sec-prefix: Section
       eq-prefix: Equation
-      fig-prefix: Figure   
+      fig-prefix: Figure
       tbl-prefix: Table
       html-math-method: katex
       template-partials:

--- a/_extensions/computo/code-block-all.lua
+++ b/_extensions/computo/code-block-all.lua
@@ -1,0 +1,71 @@
+local default_color_code = '034E79'
+local default_color_stdout = '797903'
+local default_color_stderr = '790303'
+
+local function color_fun(c, default)
+    local x = pandoc.utils.stringify(c)
+    if string.sub(x, 1, 1) == '#' then
+        return string.sub(x, 2)
+    end
+    if x == 'true' then
+        return default
+    end
+    error("Invalid color: "..x)
+end
+
+
+local injected_colors = false
+local function inject_colors_latex()
+    if not injected_colors then
+        quarto.doc.include_text("before-body", "\\definecolor{code-block-code}{HTML}{"..default_color_code.."}")
+        quarto.doc.include_text("before-body", "\\definecolor{code-block-stdout}{HTML}{"..default_color_stdout.."}")
+        quarto.doc.include_text("before-body", "\\definecolor{code-block-stderr}{HTML}{"..default_color_stderr.."}")
+        quarto.doc.include_text("before-body", "\\colorlet{shadecolor}{code-block-code!30!white}")
+        quarto.doc.include_text("before-body", "\\def\\shadecolor{\\color{shadecolor}}")
+        quarto.doc.include_text("before-body", "\\colorlet{code-block-stdout-light}{code-block-stdout!40!white}")
+        quarto.doc.include_text("before-body", "\\colorlet{code-block-stderr-light}{code-block-stderr!40!white}")
+        injected_colors = true
+    end
+end
+
+function Meta(meta)
+  for k, v in pairs(meta) do
+        if k == 'code-block-codecolor' then
+            default_color_code = color_fun(v, default_color_code)
+        end
+        if k == 'code-block-stdoutcolor' then
+            default_color_stdout = color_fun(v, default_color_stdout)
+        end
+        if k == 'code-block-stderrcolor' then
+            default_color_stderr = color_fun(v, default_color_stderr)
+        end
+    end
+    if quarto.doc.is_format("latex") then
+        inject_colors_latex()
+    end
+end
+
+function Div(div)
+    if quarto.doc.is_format("latex") then
+        if div.classes:includes('cell-output-stdout') or div.classes:includes('cell-output-display') then
+            local content = div.content
+            local change = false
+            for i,el in pairs(content) do
+                if el.t == "CodeBlock" then
+                    change = true
+                end
+            end
+            if change then
+                table.insert(content,1, pandoc.RawInline('latex', '\\begin{tcolorbox}[boxrule=0pt, enhanced, borderline west={2pt}{0pt}{code-block-stdout-light}, interior hidden, frame hidden, breakable, sharp corners, grow to left by=-1em]'))
+                table.insert(content, pandoc.RawInline('latex','\\end{tcolorbox}'))
+            end
+            return content
+        end
+        if div.classes:includes('cell-output-stderr') then
+            local content = div.content
+            table.insert(content,1, pandoc.RawInline('latex', '\\begin{tcolorbox}[boxrule=0pt, enhanced, borderline west={2pt}{0pt}{code-block-stderr-light}, interior hidden, frame hidden, breakable, sharp corners, grow to left by=-1em]'))
+            table.insert(content, pandoc.RawInline('latex','\\end{tcolorbox}'))
+            return content
+        end
+    end
+end

--- a/_extensions/computo/code-block-all.scss
+++ b/_extensions/computo/code-block-all.scss
@@ -1,0 +1,46 @@
+/*-- scss:defaults --*/
+
+// Colors
+$code-block-codecolor: $computo-color;
+$code-block-stdoutcolor: $computo-color-yellow;
+$code-block-stderrcolor: $computo-color-red;
+
+
+$code-block-codecolor-light: rgba($code-block-codecolor, 0.1);
+$code-block-codecolor-lighter: rgba($code-block-codecolor, 0.05);
+$code-block-stdoutcolor-light: rgba($code-block-stdoutcolor, 0.1);
+$code-block-stdoutcolor-lighter: rgba($code-block-stdoutcolor, 0.05);
+$code-block-stderrcolor-light: rgba($code-block-stderrcolor, 0.1);
+$code-block-stderrcolor-lighter: rgba($code-block-stderrcolor, 0.05);
+
+// Code block
+$code-block-bg: $code-block-codecolor-lighter;
+$code-block-border: $code-block-codecolor-light;
+$code-block-border-left: $code-block-codecolor;
+$code-block-border-left-size: 5px;
+
+/*-- scss:rules --*/
+
+.cell-output-display pre, .cell-output-stdout pre {
+    background-color: $code-block-stdoutcolor-lighter !important;
+    border: 1px solid $code-block-stdoutcolor-light;
+    border-radius: .25rem;
+    border-left: 5px;
+    border-left-style: solid;
+    border-left-color: $code-block-stdoutcolor;
+    padding: .4em
+}
+
+.cell-output-stderr pre {
+    background-color: $code-block-stderrcolor-lighter !important;
+    border: 1px solid $code-block-stderrcolor-light;
+    border-radius: .25rem;
+    border-left: 5px;
+    border-left-style: solid;
+    border-left-color: $code-block-stderrcolor;
+    padding: .4em
+}
+
+.cell-output pre code {
+    background-color: transparent;
+}

--- a/_extensions/computo/custom.scss
+++ b/_extensions/computo/custom.scss
@@ -17,36 +17,14 @@ $computo-color:         #034E79 !default;
 $computo-color-dark:    darken($computo-color, 10%);
 $computo-color-light:   lighten($computo-color, 60%);
 $computo-color-lighter: rgba($computo-color, 0.04);
-$computo-color-stdout: #7a7c00 !default;
-$computo-color-stdout-dark:    darken($computo-color-stdout, 10%);
-$computo-color-stdout-light:    lighten($computo-color-stdout, 60%);
-$computo-color-stdout-lighter: rgba($computo-color-stdout, 0.04);
-$computo-color-stderr: #7c0000 !default;
-$computo-color-stderr-dark:    darken($computo-color-stderr, 10%);
-$computo-color-stderr-light:    lighten($computo-color-stderr, 60%);
-$computo-color-stderr-lighter: rgba($computo-color-stderr, 0.04);
+
+$computo-color-yellow:         #797903 !default;
+$computo-color-red:         #790303 !default;
+
 
 // Theme colors
 $body-color: $grey-color-dark;
 $link-color: $computo-color;
-
-.cell-output-display pre, .cell-output-stdout pre {
-    background-color: $computo-color-stdout-lighter !important;
-    border: 1px solid $computo-color-stdout-light;
-    border-radius: .25rem;
-    border-left: 5px;
-    border-left-style: solid;
-    border-left-color: $computo-color-stdout-dark;
-}
-
-.cell-output-stderr pre {
-    background-color: $computo-color-stderr-lighter !important;
-    border: 1px solid $computo-color-stderr-light;
-    border-radius: .25rem;
-    border-left: 5px;
-    border-left-style: solid;
-    border-left-color: $computo-color-stderr-dark;
-}
 
 // Font
 $headings-font-weight: 500 !default;
@@ -64,7 +42,7 @@ $callout-border-width: 5px ;
 .callout-header {
     background-color: $computo-color-lighter !important;
     font-size: 1.1rem;
-    font-weight: 600;    
+    font-weight: 600;
     color: $computo-color-dark ;
 }
 
@@ -94,12 +72,6 @@ $navbar-bg: $computo-color;
 $navbar-fg: $white-color;
 $navbar-text-color: $white-color;
 $navbar-hover-color: #{$computo-color-light};
-
-// Code block
-$code-block-bg: $computo-color-lighter;
-$code-block-border: $computo-color-light;
-$code-block-border-left: $computo-color-dark;
-$code-block-border-left-size: 5px;
 
 /*-- scss:rules --*/
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
@jchiquet has merged changes on code display that I send by mail. However, I wrote [a general code](https://gitlab.com/jbleger/code-block-all) to improve code output in html (and a lot in pdf) for my own usage. Based on this changes, it improve a little bit the output for html, and a lot for pdf.

 - HTML before:
  ![HTML before](https://user-images.githubusercontent.com/24868098/209723418-1de739ef-ace4-404f-b763-0d07c34fa2ea.png)
 - HTML after:
  ![Capture d’écran de 2022-12-27 21-54-35](https://user-images.githubusercontent.com/24868098/209723459-5bca936b-2b45-4c7b-8243-abfc3e9a32c4.png)

 - PDF before (see page 2):
  [minial_example_before.pdf](https://github.com/computorg/computo-quarto-extension/files/10310767/minial_example_before.pdf)

 - PDF after (see page 2):
  [minial_example_after.pdf](https://github.com/computorg/computo-quarto-extension/files/10310768/minial_example_after.pdf)

_Note: I am currently preparing a submission and therefore using the template. This request is based only on my own usage of the extension. I do not have global point of view and my request can be not a good idea for other usage._