### PR TITLE
fix -- template pdf bug when a author do not have affiliation

### DIFF
--- a/_extensions/computo/partials/pdf/before-body.tex
+++ b/_extensions/computo/partials/pdf/before-body.tex
@@ -33,8 +33,9 @@
       \setlength{\parindent}{-1em}
       $if(it.department)$$it.department$$if(it.name)$, $endif$$endif$$if(it.name)$$it.name$$endif$$if(it.department)$\\$elseif(it.name)$\\$endif$
       $endfor$
-      \end{tabular}\\
+      \end{tabular}
       $endif$
+      \\
     $endfor$
   \end{tabularx}
 \end{center}


### PR DESCRIPTION
When a author do not have affiliation, the generated LaTeX from the template was buggy. This fix this bug.

This bug was spotted by @armandfavrot.